### PR TITLE
Fix empty lines not being parsed.

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -541,6 +541,9 @@ pub fn parse(input: &str) -> Result<DesktopFile, ParseError> {
     let mut current_target = EntryType::Entry(result_entry.clone());
 
     for line in lines.iter_mut() {
+        if line.content.len() == 0 {
+            continue;
+        }
         match current_target {
             EntryType::Entry(ref entry) => match line.line_type() {
                 LineType::Header => {


### PR DESCRIPTION
Empty lines with \t\n caused an empty line parsed.