### PR TITLE
Refactor icon path resolving

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,7 @@ description = "Freedesktop Desktop Entry Parser"
 
 [dependencies]
 thiserror = "2.0.7"
-freedesktop-icons = "0.4.0"
+freedesktop-icons = { version = "0.4.0", optional = true }
+
+[features]
+resolve-icons = ["dep:freedesktop-icons"]

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -76,6 +76,7 @@ pub enum IconIdentifier {
     Name(String),
 }
 
+#[cfg(feature = "resolve-icons")]
 impl IconIdentifier {
     /// Returns a path to the icon by looking up the icon in the freedesktop icon system if
     /// necessary, with size=48 and scale=1 as defaults

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -55,23 +55,40 @@ pub struct IconString {
 }
 
 impl IconString {
-    /// Attempts to find the icon's full path on the system.
-    ///
-    /// First checks if the content is a direct path to an existing file.
-    /// If not, looks up the icon name in the freedesktop icon theme system.
-    ///
-    /// # Returns
-    /// - `Some(PathBuf)` if the icon is found either as a file or in the icon theme
-    /// - `None` if the icon cannot be found
-    pub fn get_icon_path(&self) -> Option<PathBuf> {
-        if std::fs::read(&self.content).is_ok() {
-            Some(self.content.clone().into())
+    /// Converts the IconString to an IconIdentifier
+    /// by optimistically checking if it represents a valid path to a file on disk,
+    /// and assuming it is a name otherwise
+    pub fn to_identifier(self) -> IconIdentifier {
+        let path = PathBuf::from(&self.content);
+        if path.is_file() {
+            IconIdentifier::Path(path)
         } else {
-            freedesktop_icons::lookup(&self.content)
+            IconIdentifier::Name(self.content)
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum IconIdentifier {
+    /// An absolute path to the icon on disk
+    Path(PathBuf),
+    /// An icon name in the system theme
+    Name(String),
+}
+
+impl IconIdentifier {
+    /// Returns a path to the icon by looking up the icon in the freedesktop icon system if
+    /// necessary, with size=48 and scale=1 as defaults
+    ///
+    /// Returns None if an icon cannot be found
+    pub fn resolve_with_defaults(self) -> Option<PathBuf> {
+        Some(match self {
+            Self::Path(path) => path,
+            Self::Name(name) => freedesktop_icons::lookup(&name)
                 .with_size(48)
                 .with_scale(1)
-                .find()
-        }
+                .find()?,
+        })
     }
 }
 
@@ -242,7 +259,7 @@ pub enum ParseError {
     Syntax { msg: String, row: usize, col: usize },
     #[error("Parse Error: Repetitive entry at line {row:?} column {col:?}, message: {msg:?}. There should be only one entry on top of the file")]
     RepetitiveEntry { msg: String, row: usize, col: usize },
-    #[error("Parse Error: Format error at line {row:?} column {col:?}, message: {msg:?}. The first heaedr should only be about an entry")]
+    #[error("Parse Error: Format error at line {row:?} column {col:?}, message: {msg:?}. The first header should only be about an entry")]
     FormatError { msg: String, row: usize, col: usize },
     #[error("Parse Error: Internal error at line {row:?} column {col:?}, message: {msg:?}")]
     InternalError { msg: String, row: usize, col: usize },

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -76,8 +76,18 @@ pub enum IconIdentifier {
     Name(String),
 }
 
-#[cfg(feature = "resolve-icons")]
 impl IconIdentifier {
+    pub fn resolve<F>(self, resolver: F) -> Option<PathBuf>
+    where
+        F: FnOnce(String) -> Option<PathBuf>,
+    {
+        match self {
+            Self::Path(path) => Some(path),
+            Self::Name(name) => resolver(name),
+        }
+    }
+
+    #[cfg(feature = "resolve-icons")]
     /// Returns a path to the icon by looking up the icon in the freedesktop icon system if
     /// necessary, with size=48 and scale=1 as defaults
     ///


### PR DESCRIPTION
IconString::get_icon_path() is a very leaky abstraction, it sets opinionated defaults on behalf of the caller and introduces a dependency on freedesktop-icons. This PR changes that by introducing a new enum: IconIdentifier.

Rationale: This will allow a caller to use their options for looking up the icon, even a different library
```rust
let icon_string = IconString { ... };
let icon_path = icon_string.to_identifier().resolve(|name| { ... });
```
or passing an icon by name to a gui toolkit
```rust
let icon_object: example_lib::Icon = match icon_string.to_identifier() {
    IconIdentifier::Path(path) => example_lib::Icon::open_path(path),
    IconIdentifier::Name(name) => example_lib::Icon::find(name),
}
```
This also reflects the spec better: IconString can be either a path or a name, this is a tagged union, or in rust an enum.

To achieve very similar behavior to `.get_icon_path()`, use `.to_identifier().resolve_with_defaults()`. The only difference is that this will consume the original IconString. I don't know a usecase for preserving the original IconString after getting a path, but if one exists, it can be trivially done with a clone.

`.resolve_with_defaults` is feature-gated behind "resolve-icons". This allows to use the library without depending on freedesktop-icons.