### PR TITLE
Cargo manifest fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "freedesktop-file-parser"
 version = "0.3.1"
 edition = "2021"
 authors = ["David Huang jiguangllsw@gmail.com"]
-license-file = "LICENSE"
+license = "MIT"
 readme = "README.md"
 repository = "https://github.com/BL-CZY/desktop_file_parser"
 documentation = "https://github.com/BL-CZY/desktop_file_parser?tab=readme-ov-file#freedesktop-desktop-entry-parser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.3.1"
 edition = "2021"
 authors = ["David Huang jiguangllsw@gmail.com"]
 license = "MIT"
-readme = "README.md"
 repository = "https://github.com/BL-CZY/desktop_file_parser"
 documentation = "https://github.com/BL-CZY/desktop_file_parser?tab=readme-ov-file#freedesktop-desktop-entry-parser"
 description = "Freedesktop Desktop Entry Parser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 authors = ["David Huang jiguangllsw@gmail.com"]
 license = "MIT"
 repository = "https://github.com/BL-CZY/desktop_file_parser"
-documentation = "https://github.com/BL-CZY/desktop_file_parser?tab=readme-ov-file#freedesktop-desktop-entry-parser"
 description = "Freedesktop Desktop Entry Parser"
 
 [dependencies]


### PR DESCRIPTION
- Define license by SPDX name to avoid showing as "non-standard". Defining a license using `license-file` causes https://crates.io/crates/freedesktop-file-parser to show the license as "non-standard". Define it using `license = "MIT"` instead.
- Remove `readme` definition that matches the default. `README.md` is detected by default.
- Remove `documentation` field to use the default docs.rs. `documentation` should point to rustdoc-generated documentation, not a README file. Removing it uses the default, https://docs.rs/freedesktop-file-parser/ .
